### PR TITLE
Remove references to gpt-4 needing separate approval.

### DIFF
--- a/community-content/content/tutorial-azure-openai-azure-speech-gpt-4.md
+++ b/community-content/content/tutorial-azure-openai-azure-speech-gpt-4.md
@@ -34,9 +34,6 @@ In this tutorial, you learn how to:
 ## Prerequisites
 - An Azure subscription - Create a [free trial account](https://azure.microsoft.com/free)
 - Access to Azure OpenAI Service - https://aka.ms/oaiapply
-- Access to GPT-4 models in Azure OpenAI service - https://aka.ms/oai/get-gpt4
-
-
 
 ## What is the difference between Azure OpenAI and OpenAI
 Before we dive into the integration process, let’s first understand what Azure OpenAI Service is.
@@ -60,13 +57,6 @@ If your application to access the Azure OpenAI service is approved, then you can
 The Azure OpenAI service offers users access to a range of different models, such as gpt-35-turbo, gpt-35-turbo-16k, gpt-4 and gpt-4-32k, each with its own capabilities and price point. The version of both gpt-35-turbo and gpt-4 models is a new and improved 0613 model version, which comes with the enhanced steerability.
 
 ![aoai-pricing](../media/aoai-speech-python/2-aoai-pricing.png)
-
-However, it should be noted that the GPT-4 models are currently still available by request only. Existing Azure OpenAI customers can apply for access to these models by completing the form below.
-
-https://aka.ms/oai/get-gpt4
-
-
-
 
 ## Sign in to Azure OpenAI Studio
 To get started, go to https://oai.azure.com to access Azure OpenAI Studio. Sign in using credentials that have access to your Azure OpenAI resource. You can select the appropriate directory, Azure subscription, and Azure OpenAI resource during or after the sign-in process.


### PR DESCRIPTION
GPT-4 no longer requires approval for access. All approved Azure OpenAI customers have access to GPT-4 in select regions.