### PR TITLE
Update wsl-user-msft-kernel-v6.md

### DIFF
--- a/community-content/content/wsl-user-msft-kernel-v6.md
+++ b/community-content/content/wsl-user-msft-kernel-v6.md
@@ -62,7 +62,7 @@ The first step will be to build the Microsoft Linux kernel from the version 6.1.
 3. Install the required packages to build the kernel:
 
     ```bash
-    sudo apt update && sudo apt install build-essential flex bison libssl-dev libelf-dev
+    sudo apt update && sudo apt install build-essential flex bison libssl-dev libelf-dev bc pahole
     ```
 
 4. Change directory to the kernel source code:


### PR DESCRIPTION
`bc` and `pahole` are missing when i tried to compile on ubuntu 23.10, after adding them all instructions worked properly