### PR TITLE
Remove content well notification

### DIFF
--- a/community-content/content/AzTerraform-Deploy-Resource-Group-and-Azure-Blob-Storage.md
+++ b/community-content/content/AzTerraform-Deploy-Resource-Group-and-Azure-Blob-Storage.md
@@ -6,8 +6,7 @@ ms.author: cahublou #Required; a Microsoft employee's alias; don't change.
 ms.service: azure #Required; service per approved list.
 ms.topic: Azure #Required; leave this attribute/value as-is.
 ms.date: 01/22/2024 #Required; mm/dd/yyyy format.
-content_well_notification: 
-  - Human-created-Community #Required; don't change.
+contributor-type: community
 ---
 
 # Azure Terraform: Deploy Resource Group and Azure Blob Storage

--- a/community-content/content/best-practices-ai-ux.md
+++ b/community-content/content/best-practices-ai-ux.md
@@ -7,10 +7,8 @@ ms.service: artificial-intelligence
 ms.topic: concept-article
 ms.date: 10/10/2023 
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
-
 ---
+
 # Best practices for building collaborative UX with Human-AI partnership 
 
 ---

--- a/community-content/content/dapr-multi-app-run.md
+++ b/community-content/content/dapr-multi-app-run.md
@@ -7,8 +7,6 @@ ms.service: dev-environment
 ms.topic: quickstart
 ms.date: 08/22/2023
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
 ---
 
 # Quickstart: Speed up the inner development loop with Dapr multi-app run

--- a/community-content/content/discover-azure-learning-opps.md
+++ b/community-content/content/discover-azure-learning-opps.md
@@ -7,8 +7,6 @@ ms.service: azure
 ms.topic: conceptual
 ms.date: 09/19/2023
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
 ---
 
 # Discover Microsoft Azure learning, training, certifications, and career path opportunities

--- a/community-content/content/governance-community-board.md
+++ b/community-content/content/governance-community-board.md
@@ -7,8 +7,7 @@ ms.service: azure
 ms.topic: conceptual 
 ms.date: 01/12/2024 
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community #Required; don't change.
+
 ---
 
 # Governance: Community Board

--- a/community-content/content/hidden-tags-azure.md
+++ b/community-content/content/hidden-tags-azure.md
@@ -7,8 +7,7 @@ ms.service: azure-portal
 ms.topic: conceptual 
 ms.date: 09/26/2023
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # Hidden Tags in Microsoft Azure

--- a/community-content/content/how-to-enforce-dotnet-format-using-editorconfig-github-actions.md
+++ b/community-content/content/how-to-enforce-dotnet-format-using-editorconfig-github-actions.md
@@ -8,8 +8,7 @@ ms.topic: how-to
 ms.date: 09/24/2023
 ms.custom: template-how-to-pattern
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # How to enforce .NET format using EditorConfig and GitHub Actions

--- a/community-content/content/how-to-utilize-kubecost-for-cost-management-of-aks.md
+++ b/community-content/content/how-to-utilize-kubecost-for-cost-management-of-aks.md
@@ -8,8 +8,7 @@ ms.topic: how-to
 ms.date: 07/25/2023
 ms.custom: template-how-to-pattern
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # Manage cost and optimize resources in AKS with Kubecost

--- a/community-content/content/ml-for-those-who-don't-know-anything-about-ml.md
+++ b/community-content/content/ml-for-those-who-don't-know-anything-about-ml.md
@@ -7,8 +7,7 @@ ms.service: machine-learning
 ms.topic: conceptual 
 ms.date: 11/15/2023 
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # Machine Learning for those who don't know anything about Machine Learning

--- a/community-content/content/must-use-ai-features-in-power-bi.md
+++ b/community-content/content/must-use-ai-features-in-power-bi.md
@@ -7,8 +7,7 @@ ms.service: powerbi
 ms.topic: conceptual
 ms.date: 11/14/2023 
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # Must-Use AI Features in Power BI

--- a/community-content/content/remembering-the-users-in-cloud-transformation.md
+++ b/community-content/content/remembering-the-users-in-cloud-transformation.md
@@ -8,8 +8,7 @@ ms.topic: concept-article
 ms.date: 09/24/2023
 ms.custom: template-concept
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # Remembering the Users in Cloud Transformations

--- a/community-content/content/securing-backups-with-azure.md
+++ b/community-content/content/securing-backups-with-azure.md
@@ -7,8 +7,7 @@ ms.service: backup
 ms.topic: conceptual
 ms.date: 09/21/2023
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # Securing your Microsoft Azure Backups

--- a/community-content/content/tips-to-learn-data-analysis-faster.md
+++ b/community-content/content/tips-to-learn-data-analysis-faster.md
@@ -7,8 +7,7 @@ ms.service: powerbi
 ms.topic: conceptual
 ms.date: 11/14/2023 
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # Data Analysis with Power BI for Absolute Beginners

--- a/community-content/content/tutorial-azure-openai-azure-speech-gpt-4.md
+++ b/community-content/content/tutorial-azure-openai-azure-speech-gpt-4.md
@@ -7,8 +7,7 @@ ms.service: azure-ai-openai
 ms.topic: tutorial 
 ms.date: 09/03/2023
 contributor-type: community 
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # Tutorial: Integrating Azure OpenAI and Azure Speech Services to Create a Voice-Enabled Chatbot with Python and GPT-4

--- a/community-content/content/wsl-user-msft-kernel-v6.md
+++ b/community-content/content/wsl-user-msft-kernel-v6.md
@@ -8,8 +8,7 @@ ms.topic: how-to
 ms.date: 07/07/2023
 ms.custom: template-how-to-pattern
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # How to use the Microsoft Linux kernel v6 on Windows Subsystem for Linux version 2 (WSL2)

--- a/community-content/includes/example.md
+++ b/community-content/includes/example.md
@@ -7,8 +7,7 @@ ms.service: azure #Required; service per approved list. service slug assigned to
 ms.topic: overview #Required; leave this attribute/value as-is.
 ms.date: 06/16/2023 #Required; mm/dd/yyyy format.
 contributor-type: community
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 # What is example include?

--- a/community-content/templates/concept-template.md
+++ b/community-content/templates/concept-template.md
@@ -8,8 +8,7 @@ ms.topic: concept-article #Required; leave this attribute/value as-is.
 ms.date: 06/16/2023 #Required; mm/dd/yyyy format.
 ms.custom: template-concept #Required; leave this attribute/value as-is.
 contributor-type: community #Required; don't change.
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 <!--Remove all the comments in this template before you sign-off or merge to the 

--- a/community-content/templates/example.md
+++ b/community-content/templates/example.md
@@ -7,8 +7,7 @@ ms.service: azure #Required; request from Microsoft admin.
 ms.topic: conceptual #Required; leave this attribute/value as-is.
 ms.date: 06/16/2023 #Required; mm/dd/yyyy format.
 contributor-type: community #Required; don't change.
-content_well_notification: 
-  - Human-created-Community #Required; don't change.
+
 ---
 
 # What is example content?

--- a/community-content/templates/how-to-template.md
+++ b/community-content/templates/how-to-template.md
@@ -8,8 +8,7 @@ ms.topic: how-to #Required; leave this attribute/value as-is.
 ms.date: 06/16/2023 #Required; mm/dd/yyyy format.
 ms.custom: template-how-to-pattern #Required; leave this attribute/value as-is.
 contributor-type: community #Required; don't change.
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 <!--

--- a/community-content/templates/overview-template.md
+++ b/community-content/templates/overview-template.md
@@ -7,8 +7,7 @@ ms.service: azure #Required; request from Microsoft admin.
 ms.topic: overview #Required; leave this attribute/value as-is.
 ms.date: 06/16/2023 #Required; mm/dd/yyyy format.
 contributor-type: community #Required; don't change.
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 <!--

--- a/community-content/templates/quickstart-template.md
+++ b/community-content/templates/quickstart-template.md
@@ -7,8 +7,7 @@ ms.service: azure #Required; request from Microsoft admin.
 ms.topic: quickstart #Required; don't change.
 ms.date: 06/16/2023 #Required; mm/dd/yyyy format.
 contributor-type: community #Required; don't change.
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 <!--

--- a/community-content/templates/troubleshooting-template.md
+++ b/community-content/templates/troubleshooting-template.md
@@ -7,8 +7,7 @@ ms.service: azure #Required; request from Microsoft admin.
 ms.topic: troubleshooting-general #Required; leave this attribute/value as-is.
 ms.date: 06/16/2023 #Required; enter the date in the mm/dd/yyyy format.
 contributor-type: community #Required; don't change.
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 

--- a/community-content/templates/tutorial-template.md
+++ b/community-content/templates/tutorial-template.md
@@ -7,8 +7,7 @@ ms.service: azure #Required; request from Microsoft admin.
 ms.topic: tutorial #Required; leave this attribute/value as-is.
 ms.date: 06/16/2023 #Required; mm/dd/yyyy format.
 contributor-type: community #Required; don't change.
-content_well_notification: 
-  - Human-created-Community
+
 ---
 
 <!--


### PR DESCRIPTION
This pull request primarily includes changes to the metadata in various markdown files under the `community-content` directory. The key change across all files is the removal of the `content_well_notification` field and the addition of the `contributor-type` field. 

Here are the most important changes:

Metadata changes:

* [`community-content/content/AzTerraform-Deploy-Resource-Group-and-Azure-Blob-Storage.md`](diffhunk://#diff-0306c909f4eeb7d38632415faf9f83368e42ec55a32766cf6c04d88662eb07e7L9-R9): Removed `content_well_notification` and added `contributor-type`.
* [`community-content/content/best-practices-ai-ux.md`](diffhunk://#diff-0a17bb9af9dd2865c8f755d6d3fe288ae9b5dbc1e4d58045f96d87867fc229a8L10-R11): Removed `content_well_notification` and added `contributor-type`.
* [`community-content/content/dapr-multi-app-run.md`](diffhunk://#diff-3b2ffff71a7711f7b00f666d7574d36d3a84f01c74c6d45aea4869b4a4c03e82L10-L11): Removed `content_well_notification` and added `contributor-type`.
* [`community-content/content/discover-azure-learning-opps.md`](diffhunk://#diff-bb90b3a317c4150c7e3501352affbe18e65aa144ab429bab6ad197a8e04fa027L10-L11): Removed `content_well_notification` and added `contributor-type`.
* [`community-content/content/governance-community-board.md`](diffhunk://#diff-4997b8c75e6b39b747d077f1513cbd5dfd0e5b101577de62d17c75e7e9634d55L10-R10): Removed `content_well_notification` and added `contributor-type`.

Please note that the same kind of change was applied to several other files in the `community-content` directory, but for brevity, only the top five most important ones are listed here.