### PR TITLE
add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/customer-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/customer-feedback.yml
@@ -1,0 +1,66 @@
+name: "📄 community-content feedback template"
+title: "Feedback"
+description: >-
+  ⛔ This template is intended for use by the feedback control on the bottom of every page in community-content. If you aren't using the feedback control, choose one of the other templates.⛔
+labels:
+  - "needs-triage"
+body:
+  - type: markdown
+    attributes:
+      value: "## 🎁Enter your feedback🎁"
+  - type: markdown
+    attributes:
+      value: Select the issue type, and describe the issue in the text box below. Add as much detail as needed to help us resolve the issue.
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of issue
+      options:
+        - Security, privacy, or data loss risk
+        - Fix or update for existing article
+        - Suggestion for a new article
+        - Other (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: userfeedback
+    validations:
+      required: true
+    attributes:
+      label: Feedback
+      description: >-
+        If possible, please provide extended details that will add context and help the team update
+        the documentation. Additional details may not be useful for typos, grammar, formatting, etc.
+        For technical or factual errors, please include code snippets and output to show how the
+        documentation is incorrect.
+  - type: markdown
+    attributes:
+      value: "## 🚧 Article information 🚧"
+  - type: markdown
+    attributes:
+      value: "The following fields are automatically filled in. ***Don't edit them.*** Doing so will disconnect your issue from the affected article. To find other issues for this article, search for the Document ID."
+  - type: input
+    id: pageUrl
+    validations:
+      required: true
+    attributes:
+      label: Page URL
+  - type: input
+    id: contentSourceUrl
+    validations:
+      required: true
+    attributes:
+      label: Content source URL
+  - type: input
+    id: author
+    validations:
+      required: true
+    attributes:
+      label: Author
+      description: GitHub Id of the author
+  - type: input
+    id: documentVersionIndependentId
+    validations:
+      required: true
+    attributes:
+      label: Document Id


### PR DESCRIPTION
This pull request introduces a new feedback template for the community content in the `.github/ISSUE_TEMPLATE/customer-feedback.yml` file. The template is designed to streamline the process of reporting issues or providing feedback on the community content. 

The key features of this new template include:

* A clear name, title, and description to guide users on when and how to use this template.
* Labels for issue categorization.
* A structured body that prompts users to provide detailed feedback, select the type of issue, and input relevant information such as page URL, content source URL, author, and document Id.

These changes aim to improve the quality of feedback received and make it easier for the team to triage and address the issues reported.