### PR TITLE
Config open source feedback

### DIFF
--- a/community-content/docfx.json
+++ b/community-content/docfx.json
@@ -42,7 +42,13 @@
     "globalMetadata": {
       "breadcrumb_path": "/community/breadcrumb/toc.json",
       "extendBreadcrumb": true,
-      "feedback_system": "None",
+      "feedback_system": "OpenSource",
+      "feedback_help_link_url": "https://learn.microsoft.com/answers/",
+      "feedback_help_link_type": "get-help-at-qna",
+      "open_source_feedback_contributorGuideUrl": "https://learn.microsoft.com/contribute/content/",
+      "open_source_feedback_issueTitle": "Customer feedback - ",
+      "open_source_feedback_issueUrl": "https://github.com/MicrosoftDocs/community-content/issues/new?template=customer-feedback.yml",
+      "open_source_feedback_productName": "Community Content",
       "permissioned-type": "public"
     },
     "fileMetadata": {},


### PR DESCRIPTION
This pull request includes changes to the `docfx.json` file in the `community-content` directory. The changes involve updating the feedback system from "None" to "OpenSource" and adding several new metadata fields related to the feedback system. These new fields include a help link URL, a link type, a contributor guide URL, an issue title, an issue URL, and a product name.

Key changes:

* [`community-content/docfx.json`](diffhunk://#diff-1cbfbc7e9b7715130d0d28a9e5d2c0be9023189a118233e0b23945c65f70a719L45-R51): The "feedback_system" value has been changed from "None" to "OpenSource". New metadata fields related to the feedback system have been added, including "feedback_help_link_url", "feedback_help_link_type", "open_source_feedback_contributorGuideUrl", "open_source_feedback_issueTitle", "open_source_feedback_issueUrl", and "open_source_feedback_productName".