### PR TITLE
Update notification_subscribers to current team

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -16,9 +16,10 @@
     }
   ],
   "notification_subscribers": [
-    "eujuric@microsoft.com",
-    "sonia@microsoft.com",
-    "pieter.de.bruin@microsoft.com"
+    "kimberlm@microsoft.com",
+    "pidebrui@microsoft.com",
+    "sarahgaspari@microsoft.com",
+    "kichand@microsoft.com"
   ],
   "sync_notification_subscribers": [],
   "branches_to_filter": [],


### PR DESCRIPTION
Update the notification_subscribers list in .openpublishing.publish.config.json to reflect the current team.

**Removed:**
- eujuric@microsoft.com
- sonia@microsoft.com
- pieter.de.bruin@microsoft.com

**Added:**
- kimberlm@microsoft.com (Kimberly Murphy)
- pidebrui@microsoft.com (Pieter de Bruin)
- sarahgaspari@microsoft.com (Sarah Gaspari)
- kichand@microsoft.com (Kiran Chandratrey)