### PR TITLE
Fix broken link in azure-rest-api-how-to-create-a-bearer-token.md

### DIFF
--- a/community-content/content/azure-rest-api-how-to-create-a-bearer-token.md
+++ b/community-content/content/azure-rest-api-how-to-create-a-bearer-token.md
@@ -129,6 +129,6 @@ In conclusion, this brief exploration into creating and utilizing a bearer token
 
 ## See also
 
-- [Getting started with Azure API Management REST API](https://azure.microsoft.com/resources/videos/getting-started-with-azure-api-management-rest-api/)
+- [Azure API Management REST API reference](/rest/api/apimanagement/)
 - [Postman API client](https://www.getpostman.com/product/api-client)
 - [Azure REST API reference](/rest/api/azure/)


### PR DESCRIPTION
The link to the Azure API Management REST API getting started video returns a 404. This replaces it with the current [API Management REST API reference](/rest/api/apimanagement/) on Learn.

Resolves build suggestion: `other-site-link-broken` at line 132.